### PR TITLE
feat: Support all markdown list markers

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Managing checkboxes in markdown files can be tedious, especially when working wi
 
 - 🔄 Cycle through customizable checkbox states.
 - 🤹 Support for multiple state cycles.
+- 📝 Support for all standard markdown list markers (`-`, `*`, `+`)
 - ⌨️ Easy integration with keybindings.
 - 🧘 Preserve indentation when cycling checkboxes.
 - ☑️ Add checkboxes to lines that don't have them.
@@ -183,6 +184,24 @@ This plugin does not provide any default keybindings, so you’ll need to add th
 ```lua
 vim.keymap.set({ 'n', 'v' }, '<CR>', '<Cmd>CheckboxCycleNext<CR>', { noremap = true, silent = true })
 vim.keymap.set({ 'n', 'v' }, '<S-CR>', '<Cmd>CheckboxCyclePrev<CR>', { noremap = true, silent = true })
+```
+
+### List Markers
+
+The plugin supports all standard markdown list markers:
+
+```
+- [ ] Task with hyphen
+* [ ] Task with asterisk
++ [ ] Task with plus sign
+```
+
+You can freely mix different markers in the same document, and the plugin will maintain each marker when cycling states:
+
+```
+- [ ] First task
+* [x] Second task
++ [/] Third task
 ```
 
 ## 🔬 Advanced Usage

--- a/lua/checkbox-cycle/init.lua
+++ b/lua/checkbox-cycle/init.lua
@@ -20,11 +20,13 @@ function M.setup(opts)
   if type(M.config.states[1]) == 'string' then
     M.config.states = { M.config.states }
   end
-  -- Add '- ' prefix to all states if not present
+  -- Add '- ' or '* ' prefix to all states if not present
   for i, cycle in ipairs(M.config.states) do
     ---@cast cycle string[]
     for j, state in ipairs(cycle) do
-      if not state:match('^%- ') then
+      -- Check if state already has a prefix
+      if not state:match('^[%-*] ') then
+        -- Default to dash prefix if none present
         M.config.states[i][j] = '- ' .. state
       end
     end
@@ -36,7 +38,8 @@ end
 ---@return string, string|nil: Returns the leading whitespace and the checkbox pattern (or nil if not found).
 local function find_checkbox(line)
   local indent = line:match('^(%s*)') or ''
-  local checkbox = line:match('^%s*(%- %[.?%])')
+  -- Updated pattern to match both - and * before checkbox
+  local checkbox = line:match('^%s*[%-*] %[.?%]')
   return indent, checkbox
 end
 
@@ -50,8 +53,11 @@ local function tbl_indexof(tbl, value)
 end
 
 local function find_cycle_index(current_state)
+  -- Normalize the current state by replacing the prefix with '- '
+  local normalized_state = current_state:gsub('^[%-*] ', '- ')
+
   for i, cycle in ipairs(M.config.states) do
-    local index = tbl_indexof(cycle, current_state)
+    local index = tbl_indexof(cycle, normalized_state)
     if index then
       return i, index
     end
@@ -79,8 +85,14 @@ local function update_checkbox_line(line, direction, cycle_index)
   local indent, checkbox = find_checkbox(line)
 
   if checkbox then
-    local new_state = cycle_state(checkbox, direction)
-    local new_line = line:gsub(vim.pesc(indent .. checkbox), indent .. new_state)
+    -- Remove indentation from checkbox for state matching
+    local checkbox_without_indent = checkbox:match('[%-*] %[.?%]')
+    -- Extract the list marker (- or *) from the existing checkbox
+    local list_marker = checkbox:match('[%-*]')
+    -- Get the new state and replace the marker
+    local new_state = cycle_state(checkbox_without_indent, direction):gsub('^%-', list_marker)
+    -- Replace the old checkbox (with indent) with the new state (with indent)
+    local new_line = line:gsub(vim.pesc(checkbox), indent .. new_state)
     return new_line
   else
     local new_state = M.config.states[cycle_index][1]

--- a/lua/checkbox-cycle/init.lua
+++ b/lua/checkbox-cycle/init.lua
@@ -2,6 +2,15 @@ local M = {}
 
 M.config = {}
 
+local PATTERNS = {
+  MARKERS = '[%-%*%+]',
+  CHECKBOX = '%[.?%]',
+  INDENT = '^(%s*)',
+}
+
+PATTERNS.FULL_CHECKBOX = PATTERNS.MARKERS .. ' ' .. PATTERNS.CHECKBOX
+PATTERNS.FULL_CHECKBOX_WITH_INDENT = '^%s*' .. PATTERNS.FULL_CHECKBOX
+
 ---@class CheckboxCycleConfig
 ---@field states string[]|string[][] List of checkbox states to cycle through. Can be a single list or a list of lists.
 
@@ -20,12 +29,12 @@ function M.setup(opts)
   if type(M.config.states[1]) == 'string' then
     M.config.states = { M.config.states }
   end
-  -- Add '- ' or '* ' prefix to all states if not present
+  -- Add marker prefix to all states if not present
   for i, cycle in ipairs(M.config.states) do
     ---@cast cycle string[]
     for j, state in ipairs(cycle) do
       -- Check if state already has a prefix
-      if not state:match('^[%-*] ') then
+      if not state:match('^' .. PATTERNS.FULL_CHECKBOX) then
         -- Default to dash prefix if none present
         M.config.states[i][j] = '- ' .. state
       end
@@ -37,9 +46,8 @@ end
 ---@param line string: The input line to check for leading whitespace and checkbox.
 ---@return string, string|nil: Returns the leading whitespace and the checkbox pattern (or nil if not found).
 local function find_checkbox(line)
-  local indent = line:match('^(%s*)') or ''
-  -- Updated pattern to match both - and * before checkbox
-  local checkbox = line:match('^%s*[%-*] %[.?%]')
+  local indent = line:match(PATTERNS.INDENT) or ''
+  local checkbox = line:match(PATTERNS.FULL_CHECKBOX_WITH_INDENT)
   return indent, checkbox
 end
 
@@ -54,7 +62,7 @@ end
 
 local function find_cycle_index(current_state)
   -- Normalize the current state by replacing the prefix with '- '
-  local normalized_state = current_state:gsub('^[%-*] ', '- ')
+  local normalized_state = current_state:gsub('^' .. PATTERNS.MARKERS .. ' ', '- ')
 
   for i, cycle in ipairs(M.config.states) do
     local index = tbl_indexof(cycle, normalized_state)
@@ -86,9 +94,9 @@ local function update_checkbox_line(line, direction, cycle_index)
 
   if checkbox then
     -- Remove indentation from checkbox for state matching
-    local checkbox_without_indent = checkbox:match('[%-*] %[.?%]')
-    -- Extract the list marker (- or *) from the existing checkbox
-    local list_marker = checkbox:match('[%-*]')
+    local checkbox_without_indent = checkbox:match(PATTERNS.FULL_CHECKBOX)
+    -- Extract the list marker (-, * or +) from the existing checkbox
+    local list_marker = checkbox:match(PATTERNS.MARKERS)
     -- Get the new state and replace the marker
     local new_state = cycle_state(checkbox_without_indent, direction):gsub('^%-', list_marker)
     -- Replace the old checkbox (with indent) with the new state (with indent)
@@ -96,7 +104,7 @@ local function update_checkbox_line(line, direction, cycle_index)
     return new_line
   else
     local new_state = M.config.states[cycle_index][1]
-    return indent .. new_state .. ' ' .. line:gsub('^%s*', '')
+    return indent .. new_state .. ' ' .. line:gsub(PATTERNS.INDENT, '')
   end
 end
 

--- a/test/checkbox_cycle_spec.lua
+++ b/test/checkbox_cycle_spec.lua
@@ -293,4 +293,44 @@ describe('checkbox-cycle', function()
       '- [x] Item 4',
     }, vim.api.nvim_buf_get_lines(0, 0, -1, false))
   end)
+
+  it('cycles states with "+ " prefix', function()
+    vim.api.nvim_buf_set_lines(0, 0, -1, false, { '+ [ ] Unchecked item' })
+    checkbox_cycle.cycle_next()
+    assert.are.same({ '+ [x] Unchecked item' }, vim.api.nvim_buf_get_lines(0, 0, -1, false))
+  end)
+
+  it('handles mixed markers in multiple state cycles', function()
+    checkbox_cycle.setup({
+      states = {
+        { '[ ]', '[x]', '[?]' },
+        { '[!]', '[~]', '[-]' },
+      },
+    })
+
+    vim.api.nvim_buf_set_lines(0, 0, -1, false, {
+      '* [ ] First with asterisk',
+      '+ [!] Second with plus',
+      '- [?] Third with dash',
+    })
+
+    -- Test all lines
+    vim.fn.setpos('.', { 0, 1, 1, 0 })
+    vim.cmd('normal! V2j')
+    checkbox_cycle.cycle_next()
+
+    assert.are.same({
+      '* [x] First with asterisk',
+      '+ [~] Second with plus',
+      '- [ ] Third with dash',
+    }, vim.api.nvim_buf_get_lines(0, 0, -1, false))
+  end)
+
+  it('handles indented plus checkboxes correctly', function()
+    vim.api.nvim_buf_set_lines(0, 0, -1, false, { '  + [ ] Indented checkbox' })
+    checkbox_cycle.cycle_next()
+    assert.are.same({ '  + [x] Indented checkbox' }, vim.api.nvim_buf_get_lines(0, 0, -1, false))
+    checkbox_cycle.cycle_next()
+    assert.are.same({ '  + [ ] Indented checkbox' }, vim.api.nvim_buf_get_lines(0, 0, -1, false))
+  end)
 end)

--- a/test/checkbox_cycle_spec.lua
+++ b/test/checkbox_cycle_spec.lua
@@ -3,6 +3,7 @@ local checkbox_cycle = require('checkbox-cycle')
 describe('checkbox-cycle', function()
   before_each(function()
     checkbox_cycle.setup()
+    vim.cmd('set noswapfile')
   end)
 
   after_each(function()
@@ -199,6 +200,97 @@ describe('checkbox-cycle', function()
       '- [ ] Item 1',
       '- [ ] Item 2',
       '- [ ] Item 3',
+    }, vim.api.nvim_buf_get_lines(0, 0, -1, false))
+  end)
+
+  it('cycles states with "* " prefix', function()
+    vim.api.nvim_buf_set_lines(0, 0, -1, false, { '* [ ] Unchecked item' })
+    checkbox_cycle.cycle_next()
+    assert.are.same({ '* [x] Unchecked item' }, vim.api.nvim_buf_get_lines(0, 0, -1, false))
+  end)
+
+  it('preserves "* " prefix when cycling through multiple states', function()
+    checkbox_cycle.setup({
+      states = { '[ ]', '[x]', '[?]', '[!]' },
+    })
+    vim.api.nvim_buf_set_lines(0, 0, -1, false, { '* [ ] Multiple states' })
+    checkbox_cycle.cycle_next()
+    assert.are.same({ '* [x] Multiple states' }, vim.api.nvim_buf_get_lines(0, 0, -1, false))
+    checkbox_cycle.cycle_next()
+    assert.are.same({ '* [?] Multiple states' }, vim.api.nvim_buf_get_lines(0, 0, -1, false))
+    checkbox_cycle.cycle_next()
+    assert.are.same({ '* [!] Multiple states' }, vim.api.nvim_buf_get_lines(0, 0, -1, false))
+    checkbox_cycle.cycle_next()
+    assert.are.same({ '* [ ] Multiple states' }, vim.api.nvim_buf_get_lines(0, 0, -1, false))
+  end)
+
+  it('handles indented asterisk checkboxes correctly', function()
+    vim.api.nvim_buf_set_lines(0, 0, -1, false, { '  * [ ] Indented checkbox' })
+    checkbox_cycle.cycle_next()
+    assert.are.same({ '  * [x] Indented checkbox' }, vim.api.nvim_buf_get_lines(0, 0, -1, false))
+    checkbox_cycle.cycle_next()
+    assert.are.same({ '  * [ ] Indented checkbox' }, vim.api.nvim_buf_get_lines(0, 0, -1, false))
+  end)
+
+  it('cycles backwards with asterisk prefix', function()
+    checkbox_cycle.setup({
+      states = { '[ ]', '[x]', '[?]' },
+    })
+    vim.api.nvim_buf_set_lines(0, 0, -1, false, { '* [?] Going backwards' })
+    checkbox_cycle.cycle_prev()
+    assert.are.same({ '* [x] Going backwards' }, vim.api.nvim_buf_get_lines(0, 0, -1, false))
+    checkbox_cycle.cycle_prev()
+    assert.are.same({ '* [ ] Going backwards' }, vim.api.nvim_buf_get_lines(0, 0, -1, false))
+    checkbox_cycle.cycle_prev()
+    assert.are.same({ '* [?] Going backwards' }, vim.api.nvim_buf_get_lines(0, 0, -1, false))
+  end)
+
+  it('handles mixed dash and asterisk in multiple state cycles', function()
+    checkbox_cycle.setup({
+      states = {
+        { '[ ]', '[x]', '[?]' },
+        { '[!]', '[~]', '[-]' },
+      },
+    })
+
+    vim.api.nvim_buf_set_lines(0, 0, -1, false, {
+      '* [ ] First cycle with asterisk',
+      '- [!] Second cycle with dash',
+    })
+
+    -- Test first line with asterisk
+    checkbox_cycle.cycle_next()
+    assert.are.same({
+      '* [x] First cycle with asterisk',
+      '- [!] Second cycle with dash',
+    }, vim.api.nvim_buf_get_lines(0, 0, -1, false))
+
+    -- Move to second line and test
+    vim.api.nvim_win_set_cursor(0, { 2, 0 })
+    checkbox_cycle.cycle_next()
+    assert.are.same({
+      '* [x] First cycle with asterisk',
+      '- [~] Second cycle with dash',
+    }, vim.api.nvim_buf_get_lines(0, 0, -1, false))
+  end)
+
+  it('preserves markers in visual mode with mixed dash and asterisk', function()
+    vim.api.nvim_buf_set_lines(0, 0, -1, false, {
+      '* [ ] Item 1',
+      '- [ ] Item 2',
+      '* [ ] Item 3',
+      '- [ ] Item 4',
+    })
+
+    vim.fn.setpos('.', { 0, 1, 1, 0 })
+    vim.cmd('normal! V3j')
+    checkbox_cycle.cycle_next()
+
+    assert.are.same({
+      '* [x] Item 1',
+      '- [x] Item 2',
+      '* [x] Item 3',
+      '- [x] Item 4',
     }, vim.api.nvim_buf_get_lines(0, 0, -1, false))
   end)
 end)


### PR DESCRIPTION
This PR adds support for all standard markdown list markers (`-`, `*`, `+`) when cycling through checkbox states. Previously, the plugin only supported the hyphen (`-`) prefix, which limited compatibility with markdown documents using different list markers.

Resolves #2.

## Why?
- Better compatibility with existing markdown documents
- Consistent behavior across different list marker styles
- Maintains user's preferred markdown formatting
- Seamless support for documents with mixed marker usage

## Changes
- Added support for asterisk (`*`) and plus (`+`) list markers
- Refactored pattern matching to use a centralized PATTERNS table
- Preserved list markers when cycling through checkbox states
- Added tests for all marker types and mixed usage
- Improved code maintainability with named pattern constants
