### PR TITLE
fix: Preserve list markers when adding checkboxes

### DIFF
--- a/lua/checkbox-cycle/init.lua
+++ b/lua/checkbox-cycle/init.lua
@@ -104,7 +104,21 @@ local function update_checkbox_line(line, direction, cycle_index)
     return new_line
   else
     local new_state = M.config.states[cycle_index][1]
-    return indent .. new_state .. ' ' .. line:gsub(PATTERNS.INDENT, '')
+    -- Check if line already starts with a list marker
+    local list_marker = line:match('^%s*(' .. PATTERNS.MARKERS .. ')')
+
+    if list_marker then
+      -- Line already has a marker, extract it and the rest of the line
+      local line_without_marker = line:gsub('^(%s*' .. PATTERNS.MARKERS .. '%s*)', '')
+      -- Get the marker from the new state
+      local state_marker = new_state:match(PATTERNS.MARKERS)
+      -- Replace the marker in the new state with the existing marker
+      local adjusted_state = new_state:gsub('^' .. state_marker, list_marker)
+      return indent .. adjusted_state .. ' ' .. line_without_marker
+    else
+      -- No marker, add the new state as is
+      return indent .. new_state .. ' ' .. line:gsub(PATTERNS.INDENT, '')
+    end
   end
 end
 

--- a/test/checkbox_cycle_spec.lua
+++ b/test/checkbox_cycle_spec.lua
@@ -333,4 +333,19 @@ describe('checkbox-cycle', function()
     checkbox_cycle.cycle_next()
     assert.are.same({ '  + [ ] Indented checkbox' }, vim.api.nvim_buf_get_lines(0, 0, -1, false))
   end)
+
+  it('handles lines that already have a list marker', function()
+    vim.api.nvim_buf_set_lines(0, 0, -1, false, {
+      '- Task without checkbox dash',
+      '+ Task without checkbox plus',
+      '* Task without checkbox asterisk',
+    })
+    vim.cmd('normal! V2j')
+    checkbox_cycle.cycle_next()
+    assert.are.same({
+      '- [ ] Task without checkbox dash',
+      '+ [ ] Task without checkbox plus',
+      '* [ ] Task without checkbox asterisk',
+    }, vim.api.nvim_buf_get_lines(0, 0, -1, false))
+  end)
 end)


### PR DESCRIPTION
## Issue

When calling `CheckboxCycleNext` on a line that already has a list marker (`-`, `*`, or `+`) without a checkbox, the plugin incorrectly adds a checkbox before the entire line, including the marker. This results in duplicate markers.

**Before:**
```
- Task
```
becomes:
```
- [ ] - Task
```

**After fix:**
```
- Task
```
becomes:
```
- [ ] Task
```

Resolves #4 


## Changes

- Added logic to detect and preserve existing list markers when adding checkboxes
- Ensures proper formatting regardless of the marker type (`-`, `*`, or `+`)
- Maintains indentation and spacing

## Screenshot

![checkbox-existing-markers](https://github.com/user-attachments/assets/4278a5dd-b5e9-40d2-87de-5cc91d0bf84c)


